### PR TITLE
fix for_mod_3.c

### DIFF
--- a/for_mod_3.c
+++ b/for_mod_3.c
@@ -1,6 +1,6 @@
-#include <stdio.i>
+#include <stdio.h>
 int main(){
-    char str[] = "1234567890";
+    char str[9] = "123456789";
     printf("dont input longer than 9 letters:");
     scanf("%s", &str);
     printf("%s", str);

--- a/for_mod_3.c
+++ b/for_mod_3.c
@@ -1,7 +1,7 @@
 #include <stdio.h>
 int main(){
-    char str[9] = "123456789";
-    printf("dont input longer than 9 letters:");
-    scanf("%s", &str);
+    char str[9];
+    printf("don't input longer than 9 letters:");
+    scanf("%s", str);
     printf("%s", str);
 }


### PR DESCRIPTION
冒頭の<stdio.i>を<stdio.h>に直しました。
また、文字列変数strの設定において、文字数上限を設定する形に直しました。
加えて、「dont」を「don't」へ変更し、scanf関数の&を取り除きました。